### PR TITLE
Improvements to money log

### DIFF
--- a/app/DTOs/MoneyLogEntry.php
+++ b/app/DTOs/MoneyLogEntry.php
@@ -16,6 +16,7 @@ class MoneyLogEntry extends LivewireDTO implements SerializedByVerbs
         public string $description,
         public int $amount,
         public string $type,
+        public int $balance,
     ) {
     }
 

--- a/app/Events/PlayerReceivedMoney.php
+++ b/app/Events/PlayerReceivedMoney.php
@@ -29,6 +29,7 @@ class PlayerReceivedMoney extends Event
             type: $this->type,
             amount: $this->amount,
             description: $this->activity_feed_description,
+            balance: $state->availableMoney() + $this->amount,
         ));
     }
 }

--- a/app/Events/PlayerSpentMoney.php
+++ b/app/Events/PlayerSpentMoney.php
@@ -33,6 +33,7 @@ class PlayerSpentMoney extends Event
             amount: -$amount_zeroed,
             description: $this->activity_feed_description,
             type: $this->type,
+            balance: $state->availableMoney() - $amount_zeroed,
         ));
     }
 

--- a/app/Livewire/InGameNav.php
+++ b/app/Livewire/InGameNav.php
@@ -9,19 +9,11 @@ use Livewire\Component;
 
 class InGameNav extends Component
 {
-    #[Computed]
     public function moneyHistory()
     {
         return $this->player->state()->money_history;
     }
 
-    #[Computed]
-    public function headlines()
-    {
-        return $this->game->headlines;
-    }
-
-    #[Computed]
     public function scores()
     {
         return $this->game->players->map(fn ($p) => [
@@ -31,7 +23,6 @@ class InGameNav extends Component
         ])->sortByDesc('money');
     }
 
-    #[Computed]
     public function perks()
     {
         return $this->player->state()->perks;

--- a/resources/views/livewire/in-game-nav.blade.php
+++ b/resources/views/livewire/in-game-nav.blade.php
@@ -18,36 +18,38 @@
                     @foreach(collect(range($this->game->state()->current_round_number, 1)) as $round_number)
                         <p class="mb-8"> Round {{ $round_number }} </p>
                         <ul role="list" class="">
-                            @foreach($this->money_history->filter(fn ($e) => $e->round_number === $round_number) as $entry)
+                            @foreach($this->moneyHistory()->reverse()->filter(fn ($e) => $e->round_number === $round_number) as $entry)
                             <li>
                             <div class="relative pb-8">
                                 <div class="relative flex space-x-3">
-                                    @if($entry->amount > 0)
+                                    @if($entry->amount >= 0)
                                     <div>
-                                        <span class="h-8 w-8 rounded-full bg-teal flex items-center justify-center ring-8 ring-white">
-                                            💰
+                                        <span class="h-8 w-8 rounded-full bg-teal text-sm text-white font-bold flex items-center justify-center ring-8 ring-white">
+                                            +{{ $entry->amount }}
                                         </span>
                                     </div>
-                                    <div class="flex min-w-0 flex-1 justify-between pl-4 space-x-4 pt-1.5 text-teal">
+                                    <div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5 text-teal">
                                         <div>
                                         <p class="text-sm">{{ $entry->description }}</p>
                                         </div>
-                                        <div class="whitespace-nowrap text-right text-sm">
-                                        <p>{{ $entry->amount }}</p>
+                                        <div class="whitespace-nowrap text-right text-sm flex flex-row">
+                                            <div class="">
+                                                <p>{{ $entry->balance }}</p>
+                                            </div>
                                         </div>
                                     </div>
                                     @else
                                     <div>
-                                        <span class="h-8 w-8 rounded-full bg-red flex items-center justify-center ring-8 ring-white">
-                                            💸
+                                        <span class="h-8 w-8 rounded-full text-sm text-white font-bold bg-red flex items-center justify-center ring-8 ring-white">
+                                            {{ $entry->amount }}
                                         </span>
                                     </div>
-                                    <div class="flex min-w-0 flex-1 justify-between pl-4 space-x-4 pt-1.5 text-red">
+                                    <div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5 text-red">
                                         <div>
                                             <p class="text-sm">{{ $entry->description }}</p>
                                         </div>
                                         <div class="whitespace-nowrap text-right text-sm">
-                                            <p>{{ $entry->amount }}</p>
+                                            <p>{{ $entry->balance }}</p>
                                         </div>
                                     </div>
                                     @endif
@@ -86,7 +88,7 @@
                                         </tr>
                                     </thead>
                                     <tbody class="divide-y divide-gray-200">
-                                        @foreach($this->scores as $s)
+                                        @foreach($this->scores() as $s)
                                             <tr>
                                                 @if ($s['player_id'] === $this->player->id)
                                                     <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-bold text-gray-900 sm:pl-0">{{ $s['industry'] }} (you)</td>
@@ -112,7 +114,7 @@
         </div>
  
         <!-- headlines -->
-        @if($this->headlines->count() > 0)
+        @if($this->game->headlines()->count() > 0)
         <div x-disclosure class="rounded-lg bg-white shadow">
             <button
                 x-disclosure:button
@@ -129,7 +131,7 @@
                     <div class="overflow-hidden shadow-sm sm:rounded-lg">
                         <div class=" text-purple">
                             <div>
-                                @foreach($this->headlines as $h)
+                                @foreach($this->game->headlines() as $h)
                                     <p class="mt-4 font-bold">{{ $h->headline }}</p>
                                     <p class="mt-2 text-sm">{{ $h->description }}</p>
                                 @endforeach
@@ -143,7 +145,7 @@
         @endif
 
         <!-- perks -->
-        @if($this->perks->count() > 0)
+        @if($this->perks()->count() > 0)
         <div x-disclosure class="rounded-lg bg-white shadow">
             <button
                 x-disclosure:button
@@ -160,7 +162,7 @@
                     <div class="overflow-hidden shadow-sm sm:rounded-lg">
                         <div class=" text-purple">
                             <div>
-                                @foreach($this->perks as $p)
+                                @foreach($this->perks() as $p)
                                     <p class="mt-4 font-bold">{{ $p::NAME }}</p>
                                     <p class="mt-2 text-sm">{{ $p::EFFECT }}</p>
                                 @endforeach


### PR DESCRIPTION
money log is now properly in reverse chronological order, and shows your running balance: 

<img width="360" alt="Screenshot 2024-02-27 at 11 09 48 PM" src="https://github.com/johnrudolph/pork-barrel/assets/18694510/c02cb106-099a-49b6-9d82-2a499399b251">
